### PR TITLE
Switch pipeline to SQLAlchemy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Agent instructions
-Always start by reading the `README.md` file to get context on what the code does.
-Always `pip install -q -r requirements.txt` as that will be necessary in order to run tests and execute the data pipeline.
-Always add unit tests in the `/tests` directory for any feature you implement.
-After making code changes, always run `PYTHONPATH=. pytest -q` to ensure all the unit tests pass.
-After making code changes, always run `python -m finance_pipeline.main` to ensure the pipeline successfully runs end to end.
-Always end by updating the `README.md` file (if necessary) to update the documentation on what the code does.
+- Always start by reading the `README.md` file to get context on what the code does.
+- Always `pip install -q -r requirements.txt` as that will be necessary in order to run tests and execute the data pipeline.
+- Always add unit tests in the `/tests` directory for any feature you implement.
+- After making code changes, always run `PYTHONPATH=. pytest -q` to ensure all the unit tests pass.
+- After making code changes, always run `python -m finance_pipeline.main` to ensure the pipeline successfully runs end to end.
+- Always end by updating the `README.md` file (if necessary) to update the documentation on what the code does.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Finance Data Pipeline
+
+This project fetches historical stock data using `yfinance`, computes moving averages,
+and stores the results in a SQLite database.
+
+Database interactions are handled through SQLAlchemy. The pipeline can be run with:
+
+```bash
+python -m finance_pipeline.main
+```

--- a/finance_pipeline/database.py
+++ b/finance_pipeline/database.py
@@ -1,25 +1,37 @@
-import sqlite3
 from pathlib import Path
+from sqlalchemy import (
+    Column,
+    Float,
+    MetaData,
+    String,
+    Table,
+    create_engine,
+)
+from sqlalchemy.engine import Engine
 
 DB_PATH = Path("data.db")
 
-SCHEMA = """
-CREATE TABLE IF NOT EXISTS prices (
-    date TEXT,
-    open REAL,
-    high REAL,
-    low REAL,
-    close REAL,
-    volume REAL,
-    dividends REAL,
-    stock_splits REAL,
-    symbol TEXT,
-    ma7 REAL,
-    ma30 REAL
-);
-"""
+metadata = MetaData()
 
-def get_connection(db_path: Path = DB_PATH):
-    conn = sqlite3.connect(db_path)
-    conn.execute(SCHEMA)
-    return conn
+prices = Table(
+    "prices",
+    metadata,
+    Column("date", String),
+    Column("open", Float),
+    Column("high", Float),
+    Column("low", Float),
+    Column("close", Float),
+    Column("volume", Float),
+    Column("dividends", Float),
+    Column("stock_splits", Float),
+    Column("symbol", String),
+    Column("ma7", Float),
+    Column("ma30", Float),
+)
+
+
+def get_engine(db_path: Path = DB_PATH) -> Engine:
+    """Return a SQLAlchemy engine connected to the given database path."""
+    engine = create_engine(f"sqlite:///{db_path}")
+    metadata.create_all(engine)
+    return engine

--- a/finance_pipeline/main.py
+++ b/finance_pipeline/main.py
@@ -1,6 +1,7 @@
 import pandas as pd
+from sqlalchemy.engine import Engine
 from .data_fetcher import FetchConfig, fetch_data
-from .database import get_connection
+from .database import get_engine
 
 
 def compute_moving_averages(df: pd.DataFrame) -> pd.DataFrame:
@@ -20,11 +21,9 @@ def compute_moving_averages(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def load_to_db(df: pd.DataFrame) -> None:
-    conn = get_connection()
-    df.to_sql("prices", conn, if_exists="append", index_label="date")
-    conn.commit()
-    conn.close()
+def load_to_db(df: pd.DataFrame, engine: Engine | None = None) -> None:
+    engine = engine or get_engine()
+    df.to_sql("prices", engine, if_exists="append", index_label="date")
 
 
 def run_pipeline(config: FetchConfig = FetchConfig()) -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 yfinance
 pandas
 pytest
+SQLAlchemy>=2.0

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,8 @@
+from finance_pipeline.database import get_engine
+from sqlalchemy import inspect
+
+
+def test_get_engine_creates_table(tmp_path):
+    engine = get_engine(tmp_path / "test.db")
+    inspector = inspect(engine)
+    assert "prices" in inspector.get_table_names()


### PR DESCRIPTION
## Summary
- introduce SQLAlchemy engine and metadata
- update pipeline to write using SQLAlchemy
- add database engine unit test
- create a minimal README
- update dependencies

## Testing
- `PYTHONPATH=. pytest -q`
- `python -m finance_pipeline.main`

------
https://chatgpt.com/codex/tasks/task_e_6849ee9b1c7c8328aba51179265a2414