### PR TITLE
Improve moving average computation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 This project fetches historical stock data using `yfinance`, computes moving averages,
 and stores the results in a SQLite database.
 
+To ensure moving averages are accurate from the first requested date, the pipeline
+fetches an additional 30 days of historical prices prior to the configured start
+date.
+
 Database interactions are handled through SQLAlchemy. The pipeline can be run with:
 
 ```bash

--- a/finance_pipeline/data_fetcher.py
+++ b/finance_pipeline/data_fetcher.py
@@ -2,6 +2,7 @@ import yfinance as yf
 import pandas as pd
 from typing import List
 from dataclasses import dataclass, field
+from datetime import timedelta
 
 @dataclass
 class FetchConfig:
@@ -16,7 +17,9 @@ def fetch_data(config: FetchConfig) -> pd.DataFrame:
     for symbol in config.symbols:
         ticker = yf.Ticker(symbol)
         try:
-            hist = ticker.history(start=config.start, end=config.end)
+            start_dt = pd.to_datetime(config.start) - timedelta(days=30)
+            start_str = start_dt.strftime("%Y-%m-%d")
+            hist = ticker.history(start=start_str, end=config.end)
         except Exception as exc:
             print(f"Failed to fetch data for {symbol}: {exc}")
             continue

--- a/finance_pipeline/main.py
+++ b/finance_pipeline/main.py
@@ -14,6 +14,7 @@ def compute_moving_averages(df: pd.DataFrame) -> pd.DataFrame:
 
     # Normalise columns: lowercase and replace spaces with underscores
     df = df.rename(columns=lambda c: c.strip().lower().replace(" ", "_")).sort_index()
+    df.index = pd.to_datetime(df.index).tz_localize(None)
 
     # Calculate moving averages on the closing price
     df["ma7"] = df["close"].rolling(window=7).mean()
@@ -32,6 +33,7 @@ def run_pipeline(config: FetchConfig = FetchConfig()) -> None:
         print("No data fetched")
         return
     data = compute_moving_averages(data)
+    data = data.loc[pd.to_datetime(config.start): pd.to_datetime(config.end)]
     load_to_db(data)
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -29,4 +29,4 @@ def test_fetch_data():
         df = fetch_data(cfg)
         assert not df.empty
         assert 'symbol' in df.columns
-        instance.history.assert_called_once()
+        instance.history.assert_called_once_with(start='2021-12-04', end='2022-01-10')


### PR DESCRIPTION
## Summary
- fetch an extra 30 days of data to calculate moving averages from day one
- normalise fetched index time zone handling
- filter loaded data to user supplied date range
- document new behaviour in README
- update tests for new fetch logic

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q`
- `python -m finance_pipeline.main`


------
https://chatgpt.com/codex/tasks/task_e_684adc698964832891e2fd2bf62f2443