### PR TITLE
Add price-over-MA30 indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Finance Data Pipeline
 
-This project fetches historical stock data using `yfinance`, computes moving averages,
-and stores the results in a SQLite database.
+This project fetches historical stock data using `yfinance`, computes the ratio of
+the closing price to its 30-day moving average, and stores the results in a SQLite
+database.
 
-To ensure moving averages are accurate from the first requested date, the pipeline
+To ensure the moving average is accurate from the first requested date, the pipeline
 fetches an additional 30 days of historical prices prior to the configured start
 date.
 

--- a/finance_pipeline/database.py
+++ b/finance_pipeline/database.py
@@ -25,8 +25,7 @@ prices = Table(
     Column("dividends", Float),
     Column("stock_splits", Float),
     Column("symbol", String),
-    Column("ma7", Float),
-    Column("ma30", Float),
+    Column("price_over_ma30", Float),
 )
 
 

--- a/finance_pipeline/main.py
+++ b/finance_pipeline/main.py
@@ -5,20 +5,20 @@ from .database import get_engine
 
 
 def compute_moving_averages(df: pd.DataFrame) -> pd.DataFrame:
-    """Sort data and compute moving averages.
+    """Sort data and compute the price divided by the 30-day moving average.
 
     yfinance returns columns capitalized (e.g. ``Close``). To keep the
     database schema simple we normalise all column names to lowercase before
-    calculating the moving averages.
+    calculating the indicator.
     """
 
     # Normalise columns: lowercase and replace spaces with underscores
     df = df.rename(columns=lambda c: c.strip().lower().replace(" ", "_")).sort_index()
     df.index = pd.to_datetime(df.index).tz_localize(None)
 
-    # Calculate moving averages on the closing price
-    df["ma7"] = df["close"].rolling(window=7).mean()
-    df["ma30"] = df["close"].rolling(window=30).mean()
+    # Calculate 30-day moving average on the closing price and derive ratio
+    ma30 = df["close"].rolling(window=30).mean()
+    df["price_over_ma30"] = df["close"] / ma30
     return df
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -5,11 +5,14 @@ from unittest import mock
 
 
 def test_compute_moving_averages():
-    data = pd.DataFrame({'close': [1,2,3,4,5,6,7,8,9,10]})
+    data = pd.DataFrame({'close': list(range(1, 40))})
     result = compute_moving_averages(data)
-    assert result['ma7'].iloc[6] == sum(range(1,8))/7
-    assert pd.isna(result['ma7'].iloc[5])
-    assert pd.isna(result['ma30'].iloc[-1])
+    ma30 = pd.Series(data['close']).rolling(30).mean()
+    expected_ratio = data['close'] / ma30
+    expected_ratio.index = result.index
+    pd.testing.assert_series_equal(result['price_over_ma30'], expected_ratio, check_names=False)
+    assert 'ma7' not in result.columns
+    assert 'ma30' not in result.columns
 
 
 def test_fetch_data():


### PR DESCRIPTION
## Summary
- compute closing price to MA30 ratio instead of MA7/MA30
- update database schema to store `price_over_ma30`
- adjust tests for the new indicator
- update README to describe indicator

## Testing
- `PYTHONPATH=. pytest -q`
- `python -m finance_pipeline.main`

------
https://chatgpt.com/codex/tasks/task_e_684adec24acc8328a7141dacbba826de