### PR TITLE
Add Bollinger-based position logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@ the closing price to its 30-day moving average, and stores the results in a SQLi
 database. It also calculates the Bollinger Band percent (`bb_pct`) based on a
 30-day window. Stock symbols are stored once in a `stocks` table and the `prices`
 table references them via foreign keys. The pipeline assigns a `suggested_position`
-to each price row based on the `price_over_ma30` ratio. Allowed positions are
-stored in the `position` table and are "Long", "Short" and "Cash".
+to each price row based on both the `price_over_ma30` ratio and the Bollinger
+Band percent (`bb_pct`). Each indicator makes a recommendation and the final
+position is "Long" or "Short" only when they agree; otherwise the row is marked
+as "Cash". Allowed positions are stored in the `position` table and are "Long",
+"Short" and "Cash".
 
 To ensure the moving average is accurate from the first requested date, the pipeline
 fetches an additional 30 days of historical prices prior to the configured start

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -7,7 +7,7 @@ from unittest import mock
 
 
 def test_compute_indicators_and_suggested_positions():
-    data = pd.DataFrame({'close': [1]*30 + [2]})
+    data = pd.DataFrame({'close': [1]*29 + [0.8, 1.5, 0.5]})
     result = compute_indicators_and_suggested_positions(data)
     ma30 = pd.Series(data['close']).rolling(30).mean()
     expected_ratio = data['close'] / ma30
@@ -21,6 +21,7 @@ def test_compute_indicators_and_suggested_positions():
     pd.testing.assert_series_equal(result['bb_pct'], expected_bb, check_names=False)
     assert result.loc[result.index[29], 'suggested_position'] == 'Cash'
     assert result.loc[result.index[30], 'suggested_position'] == 'Long'
+    assert result.loc[result.index[31], 'suggested_position'] == 'Short'
 
 
 def test_fetch_data():


### PR DESCRIPTION
## Summary
- derive suggested positions using both price_over_ma30 and bb_pct
- test new cross-based logic for suggested positions
- document the new indicator logic

## Testing
- `PYTHONPATH=. pytest -q`
- `python -m finance_pipeline.main`

------
https://chatgpt.com/codex/tasks/task_e_684af8860b348328b1c160db58fe73ac